### PR TITLE
fixes #25, add constraint param to live.grid

### DIFF
--- a/src/lib/objectList.js
+++ b/src/lib/objectList.js
@@ -191,7 +191,8 @@ export const OBJECT_PARAMETERS = Object.freeze({
 		"touchy",
 		"directions",
 		"setcell",
-		"currentstep"
+		"currentstep",
+		"constraint"
 	]),
 	[OBJECTS.LIVE_NUMBOX] : DEFAULT_PARAMS.concat([
 		"activebgcolor",

--- a/src/nodes/paramNode.js
+++ b/src/nodes/paramNode.js
@@ -50,7 +50,8 @@ const HARDCODED_TYPES = {
 	rawaccel : ["h", "h", "d", "d", "d", "d"],
 	touchy : ["s", "s", "h", "h"],
 	setcell : ["h", "h", "h"],
-	directions: "h*"
+	directions: "h*",
+	constraint: "h*"
 };
 
 function _getHardcodedOSCTypes(type) {


### PR DESCRIPTION
Mira.frame has already been updated to expose this parameter. Constraint is a variable length array to set the cells of a live.grid when in constraint mode. This needs to be merged in order to fix [miraweb/28](https://github.com/Cycling74/miraweb/issues/28).